### PR TITLE
Add xml layout file support.

### DIFF
--- a/Sources/AutoFindViews.Build/AutoFindViews.targets
+++ b/Sources/AutoFindViews.Build/AutoFindViews.targets
@@ -21,7 +21,7 @@
 
     <Target Name="_CollectLayoutFiles">
         <ItemGroup>
-            <LayoutFiles Include="@(AndroidResource)" Condition="'%(Extension)' == '.axml' And $([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(Identity)')))) == 'Layout'"/>
+            <LayoutFiles Include="@(AndroidResource)" Condition="('%(Extension)' == '.axml' Or '%(Extension)' == '.xml') And $([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(Identity)')))) == 'Layout'"/>
         </ItemGroup>
         <ItemGroup>
 			<RelativeLayoutFiles Include="$([System.IO.Path]::GetFileName('%(LayoutFiles.Identity)'))" />


### PR DESCRIPTION
In my day by day usage of Xamarin.Android I tend to name my layouts with .xml extension to have so support on Android Studio too. Added support for xml files in this commit.